### PR TITLE
Album Art, method to allow other mods to emit websocket events, song times in seconds

### DIFF
--- a/AudicaWebsocketServer/AudicaGameStateManager.cs
+++ b/AudicaWebsocketServer/AudicaGameStateManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using AudicaWebsocketServer.util;
+using AudicaModding;
 
 namespace AudicaWebsocketServer {
 
@@ -178,6 +179,21 @@ namespace AudicaWebsocketServer {
                 newSongInfo.songLength = TimeSpan.FromMilliseconds(Convert.ToInt64(totalTimeMs)).ToString(@"m\:ss");
                 newSongInfo.ticksTotal = songEndTicks;
 
+                // Get the album art, if present.
+                if (SongDataLoader.AllSongData[this.songData.songID].HasCustomData())
+                {
+                    byte[] albumArtData = SongDataLoader.AllSongData[this.songData.songID].albumArtData;
+
+                    if (albumArtData != null)
+                    {
+                        newSongInfo.albumArtData = Convert.ToBase64String(albumArtData);
+                    }
+                    else
+                    {
+                        newSongInfo.albumArtData = "";
+                    }
+                }
+
                 AudicaSongProgress newSongProgress = new AudicaSongProgress();
                 newSongProgress.timeElapsed = TimeSpan.FromMilliseconds(Convert.ToInt64(currentTimeMs)).ToString(@"m\:ss");
                 newSongProgress.timeRemaining = TimeSpan.FromMilliseconds(Convert.ToInt64(remainingTimeMs)).ToString(@"m\:ss");
@@ -201,30 +217,6 @@ namespace AudicaWebsocketServer {
                     .Select((GameplayModifiers.Modifier mod) => GameplayModifiers.GetModifierString(mod))
                     .ToList<string>();
 
-                // FIXME: Consider whether to resurrect the gameStats stuff below.  Could be useful for cases where websocket disconnects/reconnects mid-song and needs
-                //        context of current state.
-                //AudicaGameStateManager.gameplayStats = UnityEngine.Object.FindObjectOfType<GameplayStats>();
-                //if (AudicaGameStateManager.gameplayStats)
-                //{
-                //    MelonLoader.MelonLogger.Msg("Got gameplayStats");
-                //    GameStats newGameStats = new GameStats();
-                //    newGameStats.misfireCount = gameplayStats.mMisfireCount;
-                //    newGameStats.earlyLateCount = gameplayStats.mEarlyLateCount;
-                //    newGameStats.aimMissCount = gameplayStats.mAimMissCount;
-                //    newGameStats.chainBreakCount = gameplayStats.mChainBreakCount;
-                //    newGameStats.shotMeleeCount = gameplayStats.mShotMeleeCount;
-                //    newGameStats.shotNothingCount = gameplayStats.mShotNothingCount;
-                //    newGameStats.successCount = gameplayStats.mSuccessCount;
-                //    newGameStats.sustainBreakCount = gameplayStats.mSustainBreakCount;
-                //    newGameStats.wrongHandCount = gameplayStats.mWrongHandCount;
-                //    newGameStats.wrongOrientationCount = gameplayStats.mWrongOrientationCount;
-                //    if (!this.SongState.gameStats.Equals(newGameStats))
-                //    {
-                //        changedStates.Add("GameStats");
-                //    }
-                //    this.songState.gameStats = newGameStats;
-                //}
-
                 // As we update the songState overall, determine which pieces changed, and let the caller know
                 // what changed so websocket events can be emitted.
                 // FIXME: Is this indeed the most efficient means of doing this?  Or should we look at a pub/sub / Observer pattern here?
@@ -242,7 +234,8 @@ namespace AudicaWebsocketServer {
                 this.songState.songInfo = newSongInfo;
                 this.songState.songPlayerStatus = newSongPlayerStatus;
                 this.songState.songProgress = newSongProgress;
-                
+
+
             }
 
             return changedStates;

--- a/AudicaWebsocketServer/AudicaGameStateManager.cs
+++ b/AudicaWebsocketServer/AudicaGameStateManager.cs
@@ -177,6 +177,7 @@ namespace AudicaWebsocketServer {
                 newSongInfo.difficulty = KataConfig.GetDifficultyName(AudicaGameStateManager.config.GetDifficulty());
                 newSongInfo.classification = songClass;
                 newSongInfo.songLength = TimeSpan.FromMilliseconds(Convert.ToInt64(totalTimeMs)).ToString(@"m\:ss");
+                newSongInfo.songLengthSeconds = Convert.ToInt64(Math.Floor(totalTimeMs / 1000));
                 newSongInfo.ticksTotal = songEndTicks;
 
                 // Get the album art, if present.
@@ -197,6 +198,8 @@ namespace AudicaWebsocketServer {
                 AudicaSongProgress newSongProgress = new AudicaSongProgress();
                 newSongProgress.timeElapsed = TimeSpan.FromMilliseconds(Convert.ToInt64(currentTimeMs)).ToString(@"m\:ss");
                 newSongProgress.timeRemaining = TimeSpan.FromMilliseconds(Convert.ToInt64(remainingTimeMs)).ToString(@"m\:ss");
+                newSongProgress.timeElapsedSeconds = Convert.ToInt64(Math.Floor(currentTimeMs / 1000));
+                newSongProgress.timeRemainingSeconds = Convert.ToInt64(Math.Floor(remainingTimeMs / 1000));
                 newSongProgress.progress = currentTimeMs / totalTimeMs;
                 newSongProgress.currentTick = currentTick;
 

--- a/AudicaWebsocketServer/AudicaTargetStateManager.cs
+++ b/AudicaWebsocketServer/AudicaTargetStateManager.cs
@@ -39,7 +39,7 @@ namespace AudicaWebsocketServer {
             targetHit.score = targetHit.timingScore + targetHit.aimScore;       // TODO: may need to multiply by combo? Need to test
             targetHit.tick = cue.tick;
             targetHit.targetHitPosition = targetHitPos.ToString();
-            targetHit.zOffset = cue.zOffset;
+            //targetHit.zOffset = cue.zOffset;
 
             AudicaTargetStateManager.targetHits.Add(cue.index, targetHit);
 
@@ -72,7 +72,7 @@ namespace AudicaWebsocketServer {
 
             // Figure out how to get 'early' and 'late' timings
             
-            targetMiss.zOffset = cue.zOffset;
+            //targetMiss.zOffset = cue.zOffset;
 
             AudicaTargetStateManager.targetMisses.Add(cue.index, targetMiss);
 

--- a/AudicaWebsocketServer/AudicaTargetStateManager.cs
+++ b/AudicaWebsocketServer/AudicaTargetStateManager.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using UnityEngine;
+using MelonLoader;
 
 namespace AudicaWebsocketServer {
     class AudicaTargetStateManager {
@@ -38,6 +39,7 @@ namespace AudicaWebsocketServer {
             targetHit.score = targetHit.timingScore + targetHit.aimScore;       // TODO: may need to multiply by combo? Need to test
             targetHit.tick = cue.tick;
             targetHit.targetHitPosition = targetHitPos.ToString();
+            targetHit.zOffset = cue.zOffset;
 
             AudicaTargetStateManager.targetHits.Add(cue.index, targetHit);
 
@@ -67,6 +69,10 @@ namespace AudicaWebsocketServer {
             {
                 targetMiss.reason = "Miss";
             }
+
+            // Figure out how to get 'early' and 'late' timings
+            
+            targetMiss.zOffset = cue.zOffset;
 
             AudicaTargetStateManager.targetMisses.Add(cue.index, targetMiss);
 

--- a/AudicaWebsocketServer/AudicaWebsocketServer.csproj
+++ b/AudicaWebsocketServer/AudicaWebsocketServer.csproj
@@ -32,19 +32,22 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
-      <HintPath>D:\Steam\steamapps\common\Audica\MelonLoader\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Audica\MelonLoader\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp-firstpass">
-      <HintPath>D:\Steam\steamapps\common\Audica\MelonLoader\Managed\Assembly-CSharp-firstpass.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Audica\MelonLoader\Managed\Assembly-CSharp-firstpass.dll</HintPath>
     </Reference>
     <Reference Include="Il2Cppmscorlib">
-      <HintPath>D:\Steam\steamapps\common\Audica\MelonLoader\Managed\Il2Cppmscorlib.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Audica\MelonLoader\Managed\Il2Cppmscorlib.dll</HintPath>
     </Reference>
     <Reference Include="MelonLoader">
-      <HintPath>D:\Steam\steamapps\common\Audica\MelonLoader\MelonLoader.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Audica\MelonLoader\MelonLoader.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="SongDataLoader">
+      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Audica\Mods\SongDataLoader.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -55,10 +58,10 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="UnhollowerBaseLib">
-      <HintPath>D:\Steam\steamapps\common\Audica\MelonLoader\Managed\UnhollowerBaseLib.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Audica\MelonLoader\Managed\UnhollowerBaseLib.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>D:\Steam\steamapps\common\Audica\MelonLoader\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Audica\MelonLoader\Managed\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
     <Reference Include="websocket-sharp, Version=1.0.2.59611, Culture=neutral, PublicKeyToken=5660b08a1845a91e, processorArchitecture=MSIL">
       <HintPath>..\packages\WebSocketSharp.1.0.3-rc11\lib\websocket-sharp.dll</HintPath>
@@ -78,7 +81,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy "$(TargetPath)" "D:\Steam\steamapps\common\Audica\Mods\$(TargetFileName)"
+    <PostBuildEvent>copy "$(TargetPath)" "C:\Program Files (x86)\Steam\steamapps\common\Audica\Mods\$(TargetFileName)"
 if $(ConfigurationName) == Release (
 rmdir /s /q "$(TargetDir)output-package"
 mkdir "$(TargetDir)output-package"

--- a/AudicaWebsocketServer/AudicaWebsocketServerMain.cs
+++ b/AudicaWebsocketServer/AudicaWebsocketServerMain.cs
@@ -24,6 +24,12 @@ namespace AudicaWebsocketServer
         // isn't adversely affected.
         private long lastProgressUpdate;
 
+        // For use by other mods - allows others to emit a websocket event.
+        public static void EmitWebsocketEvent(EventContainer eventContainer)
+        {
+            wssv.WebSocketServices.Broadcast(Newtonsoft.Json.JsonConvert.SerializeObject(eventContainer));
+        }
+
         public override void OnApplicationStart()
         {
             base.OnApplicationStart();
@@ -143,7 +149,7 @@ namespace AudicaWebsocketServer
                     // Ignore if there's nothing there.
                     return;
                 }
-
+                
                 AudicaTargetFailState? targetMiss = AudicaWebsocketServerMain.AudicaTargetState.TargetMiss(cue);
                 if (targetMiss != null)
                 {

--- a/AudicaWebsocketServer/Encoder.cs
+++ b/AudicaWebsocketServer/Encoder.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace AudicaWebsocketServer
 {
-	struct EventContainer
+	public struct EventContainer
     {
 		public string eventType;
 		public Object data;

--- a/AudicaWebsocketServer/Properties/AssemblyInfo.cs
+++ b/AudicaWebsocketServer/Properties/AssemblyInfo.cs
@@ -33,10 +33,10 @@ using MelonLoader;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.1.0.0")]
+[assembly: AssemblyFileVersion("1.1.0.0")]
 
 // FIXME: Use .BuildInfo.Name, Version, etc instead of hard-coding it here.
-[assembly: MelonInfo(typeof(AudicaWebsocketServer.AudicaWebsocketServerMain), "AudicaWebsocketServer", "1.0.0", "Steglasaurous")]
+[assembly: MelonInfo(typeof(AudicaWebsocketServer.AudicaWebsocketServerMain), "AudicaWebsocketServer", "1.1.0", "Steglasaurous")]
 // FIXME: Replace with the correct Audica definition, since this is NOT a universal mod. 
 [assembly: MelonGame(null, null)]

--- a/AudicaWebsocketServer/types/State.cs
+++ b/AudicaWebsocketServer/types/State.cs
@@ -66,6 +66,7 @@ namespace AudicaWebsocketServer
         public string classification;   // "ost" | "dlc" | "extra" | "custom"
         public string songLength;       // UTC
         public float ticksTotal;
+        public string albumArtData;
 
         public bool Equals(AudicaSongInfo other)
         {

--- a/AudicaWebsocketServer/types/State.cs
+++ b/AudicaWebsocketServer/types/State.cs
@@ -16,6 +16,8 @@ namespace AudicaWebsocketServer
         public float progress;
         public string timeElapsed;
         public string timeRemaining;
+        public float timeElapsedSeconds;
+        public float timeRemainingSeconds;
         public float currentTick;
 
         public bool Equals(AudicaSongProgress other)
@@ -65,6 +67,7 @@ namespace AudicaWebsocketServer
         public string difficulty;       // "beginner" | "standard" | "advanced" | "expert"
         public string classification;   // "ost" | "dlc" | "extra" | "custom"
         public string songLength;       // UTC
+        public float songLengthSeconds;
         public float ticksTotal;
         public string albumArtData;
 
@@ -129,6 +132,7 @@ namespace AudicaWebsocketServer
         public float tick;
         // Storing a string representation, as the JSON converter runs into circular references if trying to encode the Vector2 directly.
         public string targetHitPosition;
+        public float zOffset;
     }
 
     struct AudicaTargetFailState {
@@ -136,5 +140,6 @@ namespace AudicaWebsocketServer
         public string type;         // "melee" | "standard" | "sustain" | "vertical" | "horizontal" | "chain-start" | "chain" | "bomb"
         public string hand;         // "left" | "right" | "either" | "none" (e.g. for bombs)
         public string reason;       // "miss" | "aim" | "early" | "late"
+        public float zOffset;
     }
 }

--- a/AudicaWebsocketServer/types/State.cs
+++ b/AudicaWebsocketServer/types/State.cs
@@ -132,7 +132,7 @@ namespace AudicaWebsocketServer
         public float tick;
         // Storing a string representation, as the JSON converter runs into circular references if trying to encode the Vector2 directly.
         public string targetHitPosition;
-        public float zOffset;
+        //public float zOffset;
     }
 
     struct AudicaTargetFailState {
@@ -140,6 +140,6 @@ namespace AudicaWebsocketServer
         public string type;         // "melee" | "standard" | "sustain" | "vertical" | "horizontal" | "chain-start" | "chain" | "bomb"
         public string hand;         // "left" | "right" | "either" | "none" (e.g. for bombs)
         public string reason;       // "miss" | "aim" | "early" | "late"
-        public float zOffset;
+        //public float zOffset;
     }
 }

--- a/README.md
+++ b/README.md
@@ -41,10 +41,13 @@ Emitted when the player starts playing the song.  This also triggers `SongProgre
         "difficulty": "Expert",
         "classification": "extras",
         "songLength": "2:51",
-        "ticksTotal": 130400.0
+        "ticksTotal": 130400.0,
+        "albumArtData": "ALBUM_ART_DATA_HERE_OR_NULL"
     }
 }
 ```
+
+NOTE: `albumArtData` is the base64-encoded album art image, which is a png.  When no album art is available, null is returned.  
 
 ### SongRestart
 

--- a/README.md
+++ b/README.md
@@ -160,3 +160,27 @@ Emitted when the user hits the "Return to Song List" button.  Note this also sto
     "data": ""
 }
 ```
+
+## Emitting Websocket Events from Other Mods
+
+You can now emit websocket events through the same websocket connection as the built-in events.  
+
+1. In your project, include AudicaWebsocketServer.dll as a reference.
+2. Create an `EventContainer` object with an event type (can be any string), and your object data you'd like to emit.  Then call `EmitWebsocketEvent()`.  
+
+Example:
+
+```csharp
+using AudicaWebsocketServer;
+
+// ... In your code:
+
+    EventContainer eventContainer = new EventContainer();
+    eventContainer.eventType = "ExampleEvent";
+    eventContainer.data = myObject;
+
+    AudicaWebsocketServerMain.EmitWebsocketEvent(eventContainer);
+```
+
+The object set in data must be serializable by `Newtonsoft.Json.JsonConvert.SerializeObject()` (which does a pretty good job of conversion for the most part).
+

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Emitted when the player starts playing the song.  This also triggers `SongProgre
         "difficulty": "Expert",
         "classification": "extras",
         "songLength": "2:51",
+        "songLengthSeconds": 171,
         "ticksTotal": 130400.0,
         "albumArtData": "ALBUM_ART_DATA_HERE_OR_NULL"
     }
@@ -68,7 +69,9 @@ When song playing starts, this is emitted once per second.  Emission stops when 
     "data": {
         "progress": 0.0133128827,
         "timeElapsed": "0:02",
+        "timeElapsedSeconds": 2,
         "timeRemaining": "2:49",
+        "timeRemainingSeconds": 169,
         "currentTick": 1736.0
     }
 }


### PR DESCRIPTION
A minor update, but some new features!

* Song album art, if available, is emitted as a base64-encoded string in the SongSelected event.  
* Mod developers can now emit websocket events!  More info in the README..md on how to use it. 
* Added song times in seconds alongside the formatted mm:ss times to make it easier for some use cases without having to convert times into seconds. 

